### PR TITLE
main.c: change the find_themes filename for icon_themes

### DIFF
--- a/main.c
+++ b/main.c
@@ -248,7 +248,7 @@ main(int argc, char **argv)
 	/* load themes */
 	find_themes(&openbox_themes, "themes", "openbox-3/themerc");
 	find_themes(&gtk_themes, "themes", "gtk-3.0/gtk.css");
-	find_themes(&icon_themes, "icons", "scalable");
+	find_themes(&icon_themes, "icons", "index.theme");
 	find_themes(&cursor_themes, "icons", "cursors/xterm");
 
 	/* connect to gsettings */


### PR DESCRIPTION
According to the [freedesktop icon theme spec](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) index.theme must exist, scalable doesn't have to. Currently labwc-tweaks doesn't find most if not all of the icon themes I'm using and this fixes that.