### PR TITLE
Init config file

### DIFF
--- a/main.c
+++ b/main.c
@@ -281,6 +281,12 @@ main(int argc, char **argv)
 	}
 	xml_init(filename);
 
+	/* ensure all relevant nodes exist before we start getting/setting */
+	xml_add_node("/labwc_config/theme/cornerradius");
+	xml_add_node("/labwc_config/theme/name");
+	xml_add_node("/labwc_config/libinput/device/naturalscroll");
+	xml_save();
+
 	/* load themes */
 	find_themes(&openbox_themes, "themes", "openbox-3/themerc");
 	find_themes(&gtk_themes, "themes", "gtk-3.0/gtk.css");

--- a/main.c
+++ b/main.c
@@ -100,7 +100,7 @@ update(GtkWidget *widget, gpointer data)
 	environment_set("XCURSOR_THEME", COMBO_TEXT(cursor_theme_name));
 
 
-	if (!strcmp(COMBO_TEXT(openbox_theme_name), "GTK")) {
+	if (!g_strcmp0(COMBO_TEXT(openbox_theme_name), "GTK")) {
 		spawn_sync("labwc-gtktheme.py");
 	}
 

--- a/main.c
+++ b/main.c
@@ -249,18 +249,35 @@ free_theme_vector(struct themes *themes)
 	free(themes->data);
 }
 
+static const char rcxml_template[] =
+	"<?xml version=\"1.0\"?>\n"
+	"<labwc_config>\n"
+	"  <core>\n"
+	"  </core>\n"
+	"</labwc_config>\n";
+
+static void
+create_basic_rcxml(const char *filename)
+{
+	FILE *file = fopen(filename, "w");
+	if (!file) {
+		fprintf(stderr, "warn: fopen(%s) failed\n", filename);
+		return;
+	}
+	if (!fwrite(rcxml_template, sizeof(rcxml_template), 1, file)) {
+		fprintf(stderr, "warn: error writing to %s", filename);
+	}
+	fclose(file);
+}
 int
 main(int argc, char **argv)
 {
-	/* read config file */
+	/* read/create config file */
 	char filename[4096];
 	char *home = getenv("HOME");
 	snprintf(filename, sizeof(filename), "%s/%s", home, ".config/labwc/rc.xml");
-
-	struct stat st;
-	if (stat(filename, &st)) {
-		printf("error: need ~/.config/labwc/rc.xml to run\n");
-		exit(EXIT_FAILURE);
+	if (access(filename, F_OK)) {
+		create_basic_rcxml(filename);
 	}
 	xml_init(filename);
 

--- a/xml.c
+++ b/xml.c
@@ -129,6 +129,14 @@ void
 xml_init(const char *filename)
 {
 	LIBXML_TEST_VERSION
+
+	/*
+	 * These two global variables have to be set before xmlReadFile()
+	 * in order for xmlSaveFormatFile() to indent properly.
+	 */
+	xmlKeepBlanksDefault(0);
+	xmlIndentTreeOutput = 1;
+
 	ctx.filename = strdup(filename);
         ctx.doc = xmlReadFile(filename, NULL, 0);
 	if (!ctx.doc) {
@@ -139,7 +147,7 @@ xml_init(const char *filename)
 void
 xml_save(void)
 {
-	xmlSaveFile(ctx.filename, ctx.doc);
+	xmlSaveFormatFile(ctx.filename, ctx.doc, 1);
 }
 
 void

--- a/xml.h
+++ b/xml.h
@@ -10,4 +10,18 @@ char *xml_get(char *nodename);
 int xml_get_int(char *nodename);
 int xml_get_bool_text(char *nodename);
 
+/**
+ * xml_get_content - get content of node specified by xpath
+ * @xpath_expr: xpath expression for node
+ */
+char *xml_get_content(char *xpath_expr);
+
+/**
+ * xml_add_node - add xml nodes from xpath
+ * @xpath_expr: xpath expression for new node
+ * For example xpath_expr="/labwc_config/a/b/c" creates
+ * <labwc_config><a><b><c /></b></a></labwc_config>
+ */
+void xml_add_node(char *xpath_expr);
+
 #endif /* __XML_H */


### PR DESCRIPTION
@01micko 

This patch-set does the following:
- creates a [very] simple config file if missing
- creates the nodes that `labwc-tweak` reads/write if missing

It also fixes a bug and asks for code to be indented nicely on save.