### PR TITLE
Improve labwc-tweaks.desktop GenericName

### DIFF
--- a/data/labwc-tweaks.desktop
+++ b/data/labwc-tweaks.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Labwc Config
-GenericName=configuration
+GenericName=Labwc Configuration
 Comment=Configure settings for Labwc
 Exec=labwc-tweaks
 Icon=labwc-tweaks


### PR DESCRIPTION
Some menus use "GenericName":
![screen_area_dom_21:38:02_](https://github.com/labwc/labwc-tweaks/assets/10681413/77c45f24-0375-4b6e-b31f-75f201e81042)
