### PR TITLE
src/appearance.ui: limit size of corner radius spin button range

### DIFF
--- a/src/appearance.ui
+++ b/src/appearance.ui
@@ -41,7 +41,11 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QSpinBox" name="cornerRadius"/>
+    <widget class="QSpinBox" name="cornerRadius">
+     <property name="maximum">
+      <number>16</number>
+     </property>
+    </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_3">


### PR DESCRIPTION
This was created with qt6 designer.
I chose `16` because it looks ok, but I didn't check the code to see what the theoretical upper limit is of corner radius.