### PR TITLE
Simplify provision of filename for environment{Init,Save}

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -24,6 +24,7 @@ public:
 };
 
 static std::vector<std::unique_ptr<Line>> lines;
+static std::string _filename;
 
 Line::Line(void)
 {
@@ -104,6 +105,10 @@ static void processLine(QString line)
 
 void environmentInit(std::string filename)
 {
+    // Store filename in this translation unit so that environmentSave() uses the same one with no
+    // additional effort from the caller.
+    _filename = filename;
+
     if (access(filename.c_str(), F_OK)) {
         info("environment file not found '{}'", filename);
         return;
@@ -117,9 +122,9 @@ void environmentInit(std::string filename)
     stream.close();
 }
 
-void environmentSave(std::string filename)
+void environmentSave(void)
 {
-    std::ofstream ofs(filename);
+    std::ofstream ofs(_filename);
     for (auto &line : lines) {
         if (!line->isKeyValuePair) {
             ofs << line->data.toStdString() << std::endl;

--- a/src/environment.h
+++ b/src/environment.h
@@ -8,6 +8,6 @@ int environmentGetInt(QString key);
 void environmentSet(QString key, QString value);
 void environmentSetInt(QString key, int value);
 void environmentInit(std::string filename);
-void environmentSave(std::string filename);
+void environmentSave(void);
 
 #endif /* ENVIRONMENT_H */

--- a/src/maindialog.cpp
+++ b/src/maindialog.cpp
@@ -148,13 +148,8 @@ void MainDialog::onApply()
     m_pageMouse->onApply();
     m_pageLanguage->onApply();
 
-    // TODO: Get filename in a more consistent way - share common code with main.cpp
-    std::string config_home = std::getenv("HOME") + std::string("/.config/labwc");
-    std::string config_dir = std::getenv("LABWC_CONFIG_DIR") ?: config_home;
-    std::string environment_file = config_dir + "/environment";
-
     xml_save();
-    environmentSave(environment_file);
+    environmentSave();
 
     /* reconfigure labwc */
     if (!fork()) {


### PR DESCRIPTION
...to avoid having to working it out against in maindialog.cpp ::onApply() method. Simply just remember the filename in the environment.cpp translation unit.

@stefonarch Are you happy carry on doing some independent peer-reviewing? Just say if it gets too much.