### PR TITLE
Finetune template layout

### DIFF
--- a/src/template.ui
+++ b/src/template.ui
@@ -27,7 +27,7 @@
            <number>8</number>
           </property>
           <item row="0" column="0">
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="label_1">
             <property name="text">
              <string>ComboBox Test</string>
             </property>
@@ -35,6 +35,30 @@
           </item>
           <item row="0" column="1">
            <widget class="QComboBox" name="comboBox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Checkbox Test</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBox">
+            <property name="text">
+             <string>Enable in special situation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>ComboBox Test2</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="comboBox_2"/>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
@Consolatis @stefonarch 

This PR tweaks the layout of groupbox1 of template.ui a bit. See picture below. 

<img width="645" height="515" alt="20251223_16h56m48s_grim" src="https://github.com/user-attachments/assets/a56d0774-22f4-47dd-bae3-58f0ca0001e2" />

It appears to me that there is not obvious standard for the positioning of check-boxes.

There is a good example halfway down this page: https://develop.kde.org/hig/text_and_labels/

Also see: https://develop.kde.org/hig/getting_input/
