### PR TITLE
Prettify keyboard page

### DIFF
--- a/src/keyboard.ui
+++ b/src/keyboard.ui
@@ -13,6 +13,9 @@
      </property>
      <widget class="QWidget" name="scrollAreaWidgetContents">
       <layout class="QVBoxLayout" name="main_layout">
+       <property name="spacing">
+        <number>30</number>
+       </property>
        <!-- General Settings -->
        <item>
         <widget class="QGroupBox" name="groupBox_General">


### PR DESCRIPTION
Without last commit:

<img width="510" height="659" alt="20251223_21h09m28s_grim" src="https://github.com/user-attachments/assets/fd7ee723-c560-49fd-ae18-cf45a5c9464f" />


With last commit:

<img width="660" height="651" alt="20251223_21h15m44s_grim" src="https://github.com/user-attachments/assets/ff3ed733-b060-443e-9716-8b3cffa5d351" />

I prefer the final version, but welcome thoughts from @Consolatis @stefonarch 

Aiming to merge some time tomorrow.