### PR TITLE
behaviour.ui: remove scroll area border

### DIFF
--- a/src/behaviour.ui
+++ b/src/behaviour.ui
@@ -13,6 +13,9 @@
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
+     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
This PR removes the scroll area border shown in this pic:

<img width="681" height="625" alt="20251225_20h06m05s_grim" src="https://github.com/user-attachments/assets/47180067-48e3-4353-887d-e87b2a0ff1f5" />
