### PR TITLE
settings: set environment-file from set{Int,Str,Bool}

### DIFF
--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -153,7 +153,7 @@ void Keyboard::onApply()
      */
     QString layout = m_model->getXkbDefaultLayout();
     if (!layout.isEmpty()) {
-        environmentSet("XKB_DEFAULT_LAYOUT", layout);
+        setStr("XKB_DEFAULT_LAYOUT", layout);
         environmentSet("XKB_DEFAULT_VARIANT", "");
     }
 
@@ -161,5 +161,5 @@ void Keyboard::onApply()
     setInt("/labwc_config/keyboard/repeatDelay", ui->repeatDelay->value());
     setBool("/labwc_config/keyboard/numlock", ui->numlock->isChecked());
 
-    environmentSet("XKB_DEFAULT_OPTIONS", DATA(ui->layoutGrpSwitcher));
+    setStr("XKB_DEFAULT_OPTIONS", DATA(ui->layoutGrpSwitcher));
 }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -168,6 +168,6 @@ void Mouse::onApply()
     setFloat("/labwc_config/libinput/device/scrollFactor", ui->scrollFactor->value());
 
     /* ~/.config/labwc/environment */
-    environmentSet("XCURSOR_THEME", TEXT(ui->cursorTheme));
-    environmentSetInt("XCURSOR_SIZE", ui->cursorSize->value());
+    setStr("XCURSOR_THEME", TEXT(ui->cursorTheme));
+    setInt("XCURSOR_SIZE", ui->cursorSize->value());
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -231,6 +231,11 @@ int getBool(QString name)
     return std::get<int>(setting->value());
 }
 
+//
+// The setters below are for key=value pairs in "rc.xml" and "environment". More complex
+// configuration involving objects like `<keybind>` cannot be managed through these.
+//
+
 void setInt(QString name, int value)
 {
     std::shared_ptr<Setting> setting = retrieve(name);
@@ -240,12 +245,23 @@ void setInt(QString name, int value)
     }
     if (setting->valueType() != LAB_VALUE_TYPE_INT) {
         qDebug() << "setInt(): not valid int setting" << name << value;
+        return;
     }
     if (value == std::get<int>(setting->value())) {
         return;
     }
-    xpath_add_node(name.toStdString().c_str());
-    xml_set_num(name.toStdString().c_str(), value);
+    switch (setting->fileType()) {
+    case LAB_FILE_TYPE_RCXML:
+        xpath_add_node(name.toStdString().c_str());
+        xml_set_num(name.toStdString().c_str(), value);
+        break;
+    case LAB_FILE_TYPE_ENVIRONMENT:
+        environmentSetInt(name, value);
+        break;
+    case LAB_FILE_TYPE_UNKNOWN:
+    default:
+        warn("cannot handle file type associated with '{}'", name.toStdString());
+    }
     setting->setValue(value);
     info("'{} has changed to '{}'", name.toStdString(), value);
 }
@@ -259,12 +275,23 @@ void setFloat(QString name, float value)
     }
     if (setting->valueType() != LAB_VALUE_TYPE_FLOAT) {
         qDebug() << "setFloat(): not valid float setting" << name << value;
+        return;
     }
     if (value == std::get<float>(setting->value())) {
         return;
     }
-    xpath_add_node(name.toStdString().c_str());
-    xml_set_num(name.toStdString().c_str(), value);
+    switch (setting->fileType()) {
+    case LAB_FILE_TYPE_RCXML:
+        xpath_add_node(name.toStdString().c_str());
+        xml_set_num(name.toStdString().c_str(), value);
+        break;
+    case LAB_FILE_TYPE_ENVIRONMENT:
+        warn("do not yet support setting floats in environment file");
+        break;
+    case LAB_FILE_TYPE_UNKNOWN:
+    default:
+        warn("cannot handle file type associated with '{}'", name.toStdString());
+    }
     setting->setValue(value);
     info("'{} has changed to '{}'", name.toStdString(), value);
 }
@@ -278,12 +305,23 @@ void setStr(QString name, QString value)
     }
     if (setting->valueType() != LAB_VALUE_TYPE_STRING) {
         qDebug() << "setStr(): not valid string setting" << name << value;
+        return;
     }
     if (value == std::get<QString>(setting->value())) {
         return;
     }
-    xpath_add_node(name.toStdString().c_str());
-    xml_set(name.toStdString().c_str(), value.toStdString().c_str());
+    switch (setting->fileType()) {
+    case LAB_FILE_TYPE_RCXML:
+        xpath_add_node(name.toStdString().c_str());
+        xml_set(name.toStdString().c_str(), value.toStdString().c_str());
+        break;
+    case LAB_FILE_TYPE_ENVIRONMENT:
+        environmentSet(name, value);
+        break;
+    case LAB_FILE_TYPE_UNKNOWN:
+    default:
+        warn("cannot handle file type associated with '{}'", name.toStdString());
+    }
     setting->setValue(value);
     info("'{} has changed to '{}'", name.toStdString(), value.toStdString());
 }
@@ -297,12 +335,23 @@ void setBool(QString name, int value)
     }
     if (setting->valueType() != LAB_VALUE_TYPE_BOOL) {
         qDebug() << "setBool(): not valid bool setting" << name << value;
+        return;
     }
     if (value == std::get<int>(setting->value())) {
         return;
     }
-    xpath_add_node(name.toStdString().c_str());
-    xml_set(name.toStdString().c_str(), value ? "yes" : "no");
+    switch (setting->fileType()) {
+    case LAB_FILE_TYPE_RCXML:
+        xpath_add_node(name.toStdString().c_str());
+        xml_set(name.toStdString().c_str(), value ? "yes" : "no");
+        break;
+    case LAB_FILE_TYPE_ENVIRONMENT:
+        environmentSetInt(name, value);
+        break;
+    case LAB_FILE_TYPE_UNKNOWN:
+    default:
+        warn("cannot handle file type associated with '{}'", name.toStdString());
+    }
     setting->setValue(value);
     info("'{} has changed to '{}'", name.toStdString(), value);
 }


### PR DESCRIPTION
...instead of using envionrmentSet* functions directly.

This gives for better control so that for example XCURSOR_SIZE is only written to file if different from default