### PR TITLE
Use nodename format baz.bar.foo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(PROJECT_SOURCES
     src/find-themes.cpp src/find-themes.h
     src/pair.h
     src/parse-bool.cpp src/parse-bool.h
+    src/nodename.cpp src/nodename.h
 
     src/appearance.cpp src/appearance.h src/appearance.ui
     src/behaviour.cpp src/behaviour.h src/behaviour.ui
@@ -88,12 +89,12 @@ lxqt_translate_desktop(PROJECT_DESKTOP_FILES
 #===================================================================================================
 include(CTest)
 
-add_executable(t1000 tests/t1000-add-xpath-node.cpp tests/tap.cpp src/xml.cpp src/parse-bool.cpp)
+add_executable(t1000 tests/t1000-add-xpath-node.cpp tests/tap.cpp src/xml.cpp src/parse-bool.cpp src/nodename.cpp)
 target_link_libraries(t1000 PRIVATE ${GLIB_LDFLAGS} ${LIBXML2_LIBRARIES})
 target_include_directories(t1000 PRIVATE ${GLIB_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR})
 add_test(t1000 t1000)
 
-add_executable(t1001 tests/t1001-nodenames.cpp tests/tap.cpp src/parse-bool.cpp)
+add_executable(t1001 tests/t1001-nodenames.cpp tests/tap.cpp src/parse-bool.cpp src/nodename.cpp)
 target_link_libraries(t1001 PRIVATE ${GLIB_LDFLAGS} ${LIBXML2_LIBRARIES})
 target_include_directories(t1001 PRIVATE ${GLIB_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR})
 add_test(t1001 t1001)

--- a/src/log.h
+++ b/src/log.h
@@ -5,6 +5,7 @@
 
 enum LogLevel {
     FATAL,
+    ERROR,
     WARN,
     INFO,
 };
@@ -14,6 +15,8 @@ constexpr const char *log_level_string(LogLevel level)
     switch (level) {
     case LogLevel::FATAL:
         return "fatal";
+    case LogLevel::ERROR:
+        return "error";
     case LogLevel::WARN:
         return "warn";
     case LogLevel::INFO:
@@ -29,6 +32,7 @@ static inline void _log(LogLevel level, std::format_string<Args...> fmt, Args &&
     std::string msg = std::vformat(fmt.get(), std::make_format_args(args...));
     switch (level) {
     case LogLevel::FATAL:
+    case LogLevel::ERROR:
         msg = std::string("\033[1;31m") + log_level_string(level) + ": " + msg + "\033[0m";
         break;
     case LogLevel::WARN:
@@ -47,6 +51,11 @@ static inline void _log(LogLevel level, std::format_string<Args...> fmt, Args &&
     {                                                                                             \
         _log(LogLevel::FATAL, "[{}:{}] {}", __FILE__, __LINE__, std::format(fmt, ##__VA_ARGS__)); \
         exit(EXIT_FAILURE);                                                                       \
+    }
+
+#define err(fmt, ...)                                                                             \
+    {                                                                                             \
+        _log(LogLevel::ERROR, "[{}:{}] {}", __FILE__, __LINE__, std::format(fmt, ##__VA_ARGS__)); \
     }
 
 #define warn(fmt, ...)                                                                           \

--- a/src/nodename.cpp
+++ b/src/nodename.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "nodename.h"
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <ranges>
+#include <string>
+#include <vector>
+
+static std::vector<std::string> splitIgnoringEmptyParts(const std::string &s, char delim)
+{
+    auto has_content = [](auto const &s) { return s.size() > 0; };
+    auto parts = s | std::views::split(delim) | std::views::filter(has_content)
+            | std::ranges::to<std::vector<std::string>>();
+    return parts;
+}
+
+std::string nodenameFromXPath(std::string xpath)
+{
+    auto parts = splitIgnoringEmptyParts(xpath, '/');
+    std::reverse(parts.begin(), parts.end());
+    std::string nodename;
+    for (auto part : parts) {
+        nodename.append(part);
+        nodename.append(".");
+    }
+    if (!nodename.empty() && nodename.back() == '.') {
+        nodename.pop_back();
+    }
+    return nodename;
+}

--- a/src/nodename.h
+++ b/src/nodename.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __NODENAME_H
+#define __NODENAME_H
+#include <string>
+
+std::string nodenameFromXPath(std::string xpath);
+
+#endif // __NODENAME_H

--- a/src/setting.h
+++ b/src/setting.h
@@ -34,7 +34,7 @@ public:
     void setValue(std::variant<int, float, QString> value);
 
 private:
-    QString m_name;
+    QString m_name; // xpath-style like /foo/bar/baz
     enum settingFileType m_fileType;
     enum settingValueOrigin m_valueOrigin;
     enum settingValueType m_valueType;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,10 +1,12 @@
 #include "settings.h"
 #include <QDebug>
+#include <string>
 #include <variant>
 #include "log.h"
 #include "environment.h"
 #include "macros.h"
 #include "xml.h"
+#include "nodename.h"
 
 //~ We try not to deal with raw pointers, but keeping *settings in this
 // translation unit just helps not trickle it through lots of QWidget
@@ -60,7 +62,7 @@ void settingsInit(std::vector<std::shared_ptr<Setting>> *settings)
     settingsAddXmlBoo("/labwc_config/theme/dropShadowsOnTiled", false);
     settingsAddXmlStr("/labwc_config/theme/icon", "");
     settingsAddXmlStr("/labwc_config/theme/maximizedDecoration", "titlebar");
-    settingsAddXmlStr("/labwc_config/core/decoration", "Server");
+    settingsAddXmlStr("/labwc_config/core/decoration", "server");
 
     // Behaviour
     settingsAddXmlStr("/labwc_config/placement/policy", "cascade");
@@ -79,7 +81,7 @@ void settingsInit(std::vector<std::shared_ptr<Setting>> *settings)
     settingsAddXmlBoo("/labwc_config/theme/keepBorder", true);
     settingsAddXmlInt("/labwc_config/resize/cornerRange", 8);
     settingsAddXmlInt("/labwc_config/resize/resizeMinimumArea", 8);
-    settingsAddXmlStr("/labwc_config/resize/popupShow", "Never");
+    settingsAddXmlStr("/labwc_config/resize/popupShow", "never");
     settingsAddXmlInt("/labwc_config/magnifier/width", 400);
     settingsAddXmlInt("/labwc_config/magnifier/height", 400);
     settingsAddXmlFlt("/labwc_config/magnifier/initScale", 2.0f);
@@ -215,10 +217,12 @@ void setStr(QString name, QString value)
         return;
     }
     switch (setting->fileType()) {
-    case LAB_FILE_TYPE_RCXML:
+    case LAB_FILE_TYPE_RCXML: {
         xpath_add_node(name.toStdString().c_str());
-        xml_set(name.toStdString().c_str(), value.toStdString().c_str());
+        std::string nodename = nodenameFromXPath(name.toStdString());
+        xml_set(nodename.c_str(), value.toStdString().c_str());
         break;
+    }
     case LAB_FILE_TYPE_ENVIRONMENT:
         environmentSet(name, value);
         break;
@@ -245,10 +249,12 @@ void setInt(QString name, int value)
         return;
     }
     switch (setting->fileType()) {
-    case LAB_FILE_TYPE_RCXML:
+    case LAB_FILE_TYPE_RCXML: {
         xpath_add_node(name.toStdString().c_str());
-        xml_set_num(name.toStdString().c_str(), value);
+        std::string nodename = nodenameFromXPath(name.toStdString());
+        xml_set_num(nodename.c_str(), value);
         break;
+    }
     case LAB_FILE_TYPE_ENVIRONMENT:
         environmentSetInt(name, value);
         break;
@@ -275,10 +281,12 @@ void setBool(QString name, int value)
         return;
     }
     switch (setting->fileType()) {
-    case LAB_FILE_TYPE_RCXML:
+    case LAB_FILE_TYPE_RCXML: {
         xpath_add_node(name.toStdString().c_str());
-        xml_set(name.toStdString().c_str(), value ? "yes" : "no");
+        std::string nodename = nodenameFromXPath(name.toStdString());
+        xml_set(nodename.c_str(), value ? "yes" : "no");
         break;
+    }
     case LAB_FILE_TYPE_ENVIRONMENT:
         environmentSetInt(name, value);
         break;
@@ -305,10 +313,12 @@ void setFloat(QString name, float value)
         return;
     }
     switch (setting->fileType()) {
-    case LAB_FILE_TYPE_RCXML:
+    case LAB_FILE_TYPE_RCXML: {
         xpath_add_node(name.toStdString().c_str());
-        xml_set_num(name.toStdString().c_str(), value);
+        std::string nodename = nodenameFromXPath(name.toStdString());
+        xml_set_num(nodename.c_str(), value);
         break;
+    }
     case LAB_FILE_TYPE_ENVIRONMENT:
         warn("do not yet support setting floats in environment file");
         break;

--- a/tests/t1001-nodenames.cpp
+++ b/tests/t1001-nodenames.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 	xmlNode *node = xpath_get_node((xmlChar *)"/labwc_config/core/gap");
 	char *name = nodename(node, buffer, sizeof(buffer));
 	xml_finish();
-	test(name, "/labwc_config/core/gap");
+	test(name, "gap.core.labwc_config");
 
 	unlink(in);
 	return exit_status();


### PR DESCRIPTION
...instead of /foo/bar/baz so that attributes names containing dots can be supported as in the example below:

    <keybind name.action="foo">

Also change [user-override] log message to something more helpful.