### PR TITLE
Silenced warnings

### DIFF
--- a/src/about.ui
+++ b/src/about.ui
@@ -96,7 +96,7 @@
          </widget>
         </item>
         <item row="5" column="0">
-         <widget class="QLabel" name="link">
+         <widget class="QLabel" name="web">
           <property name="text">
            <string>Website</string>
           </property>
@@ -200,7 +200,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="link">
+         <widget class="QLabel" name="development">
           <property name="text">
            <string>Development</string>
           </property>

--- a/src/behaviour.ui
+++ b/src/behaviour.ui
@@ -131,7 +131,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <spacer name="horizontalSpacer_followMouseRequiresMovement">
+           <spacer name="horizontalSpacer_followMouseRequiresMovement_1">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
             </property>

--- a/src/keyboard.ui
+++ b/src/keyboard.ui
@@ -100,7 +100,7 @@
            <widget class="QListView" name="layoutView"/>
           </item>
           <item row="0" column="2">
-           <spacer name="horizontalSpacer">
+           <spacer name="horizontalSpacer_1">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
             </property>

--- a/src/template.ui
+++ b/src/template.ui
@@ -89,7 +89,7 @@
            </widget>
           </item>
           <item row="0" column="2">
-           <spacer name="horizontalSpacer">
+           <spacer name="horizontalSpacer_1">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
             </property>


### PR DESCRIPTION
```
AutoUic: /home/stef/git/labwc-tweaks/src/about.ui: Warning: The name 'link' (QLabel) is already in use, defaulting to 'link1'.
AutoUic: /home/stef/git/labwc-tweaks/src/behaviour.ui: Warning: The name 'horizontalSpacer_followMouseRequiresMovement' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer_followMouseRequiresMovement1'.
AutoUic: /home/stef/git/labwc-tweaks/src/keyboard.ui: Warning: The name 'horizontalSpacer' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer1'.
AutoUic: /home/stef/git/labwc-tweaks/src/template.ui: Warning: The name 'horizontalSpacer' (QSpacerItem) is already in use, defaulting to 'horizontalSpacer1'. 