### PR TITLE
Added Wlroots version in about tab.

### DIFF
--- a/src/about.cpp
+++ b/src/about.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QDir>
+#include <QRegularExpression>
 #include "./ui_about.h"
 
 About::About(QWidget *parent) : QWidget(parent), ui(new Ui::pageAbout)
@@ -45,6 +46,15 @@ void About::loadInfo()
     ui->nlsValue->setText(out.contains("+nls") ? "✔" : "✘");
     ui->rsvgValue->setText(out.contains("+rsvg") ? "✔" : "✘");
     ui->libsfdoValue->setText(out.contains("+libsfdo") ? "✔" : "✘");
+
+    QRegularExpression re("wlroots-(\\d+\\.\\d+\\.\\d+)");
+    QRegularExpressionMatch match = re.match(out);
+
+    if (match.hasMatch()) {
+        ui->wlrootsVersionValue->setText(match.captured(1));
+    } else {
+        ui->wlrootsVersionValue->setText("not revealed");
+    }
 
     QString labwcLink = QStringLiteral("<a href=\"https://labwc.github.io/\">labwc.github.io</a>");
     ui->labwcLinkValue->setText(labwcLink);

--- a/src/about.ui
+++ b/src/about.ui
@@ -40,69 +40,83 @@
          </widget>
         </item>
         <item row="1" column="0">
+         <widget class="QLabel" name="web">
+          <property name="text">
+           <string>Wlroots Version</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="wlrootsVersionValue">
+          <property name="text">
+           <string></string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
          <widget class="QLabel" name="xwaylandCaption">
           <property name="text">
            <string>XWayland support</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QLabel" name="xwaylandValue">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="nlsCaption">
           <property name="text">
            <string>Native language support</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QLabel" name="nlsValue">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="rsvgCaption">
           <property name="text">
            <string>SVG icon support</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QLabel" name="rsvgValue">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="libsfdoCaption">
           <property name="text">
            <string>Icon support with libsfdo</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QLabel" name="libsfdoValue">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="web">
           <property name="text">
            <string>Website</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QLabel" name="labwcLinkValue">
           <property name="text">
            <string></string>


### PR DESCRIPTION
<img width="693" height="698" alt="tweaks" src="https://github.com/user-attachments/assets/0008d28d-61ae-4f83-9c23-f70ce58c1ab7" />

"not revealed" for older versions could also be replaced by "Unknown" as in other items, not sure.

Disclaimer: regex is suggested by LLM.