### PR TITLE
Fix appstream validation errors

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -10,6 +10,7 @@ list(APPEND PROJECT_KEYWORDS   "labwc;wayland;compositor")
 set(PROJECT_AUTHOR_NAME        "Labwc Team")
 set(PROJECT_COPYRIGHT_YEAR     "2024")  # TODO: from git
 set(PROJECT_DESCRIPTION        "Labwc Wayland compositor settings")
+set(PROJECT_DESCRIPTION_LONG   "labwc-tweaks is a Qt configuration tool for Labwc. This application allows you to configure Labwc's appearance and behavior, including mouse and keyboard input.")
 set(PROJECT_ORGANIZATION_NAME  "labwc")
 set(PROJECT_ORGANIZATION_URL   "${PROJECT_ORGANIZATION_NAME}.github.io")
 set(PROJECT_ORGANIZATION_ID    "io.github.${PROJECT_ORGANIZATION_NAME}")

--- a/data/labwc_tweaks.appdata.xml.in
+++ b/data/labwc_tweaks.appdata.xml.in
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>@PROJECT_APPSTREAM_ID@</id>
+  <id>@PROJECT_ORGANIZATION_ID@.@PROJECT_APPSTREAM_ID@</id>
   <metadata_license>@PROJECT_APPSTREAM_SPDX_ID@</metadata_license>
   <project_license>@PROJECT_SPDX_ID@</project_license>
   <name>@PROJECT_NAME@</name>
   <summary>@PROJECT_DESCRIPTION@</summary>
   <content_rating type="oars-1.0" />
-@PROJECT_DESCRIPTION_HTML@
+  <description>
+    <p>
+      @PROJECT_DESCRIPTION_LONG@
+    </p>
+  </description>
   <project_group>@PROJECT_ORGANIZATION_NAME@</project_group>
   <developer id="@PROJECT_ORGANIZATION_ID@">
     <name>@PROJECT_AUTHOR_NAME@</name>


### PR DESCRIPTION
Closes #256.

These validation errors can be seen like this, after building the appdata file with cmake:
```
appstreamcli validate --pedantic --explain build/labwc_tweaks.appdata.xml
```